### PR TITLE
Fixed incorrect question in the Forms chapter

### DIFF
--- a/data/forms.yml
+++ b/data/forms.yml
@@ -76,10 +76,10 @@ questions:
             - {value: "Request data",    correct: true}
             - {value: "View data",       correct: false}
     -
-        question: 'Which ones of these types extends from TextType?'
+        question: 'Which one of these types extends from text?'
         answers:
-            - {value: "money",    correct: true}
-            - {value: "currency", correct: true}
+            - {value: "money",    correct: false}
+            - {value: "currency", correct: false}
             - {value: "textarea", correct: true}
             - {value: "surname",  correct: false}
     -


### PR DESCRIPTION
All of field type classes are inherited from AbstractType class, not TextType. According to documentation, textarea inherits "text" field type, and all others inherit "form" field type.