### PR TITLE
HTTP: Fixed accessor to accept $request->get()

### DIFF
--- a/data/http.yml
+++ b/data/http.yml
@@ -29,7 +29,7 @@ questions:
             - {value: "$request->query->get('foo');",     correct: true}
             - {value: "$request->request->get('foo');",   correct: false}
             - {value: "{$request->query->all()}['foo'];", correct: true}
-            - {value: "$request->get('foo');",            correct: false}
+            - {value: "$request->get('foo');",            correct: true}
     -
         question: 'How to access the `bar` POST parameter from Request object $request ?'
         answers:


### PR DESCRIPTION
`$request->get('foo')` is actually a good answer.

Ref https://github.com/symfony/symfony/blob/v3.0.4/src/Symfony/Component/HttpFoundation/Request.php#L722-L724