### PR TITLE
Fixed wrong answer with PHPUnit at() calls

### DIFF
--- a/data/automated-tests.yml
+++ b/data/automated-tests.yml
@@ -24,10 +24,10 @@ questions:
     -
         question: 'Using PHPUnit, which method allows to specify a mock response on second call?'
         answers:
-            - {value: $mock->expects($this->at(2)),      correct: true}
+            - {value: $mock->expects($this->at(1)),      correct: true}
+            - {value: $mock->expects($this->at(2)),      correct: false}
             - {value: $mock->expects($this->exactly(2)), correct: false}
             - {value: $mock->expects($this->on(2)),      correct: false}
-            - {value: $mock->expects($this->call(2)),    correct: false}
     -
         question: 'Using PHPUnit, which method allows you to expect an exception to be thrown?'
         answers:


### PR DESCRIPTION
`at()` calls in test cases are 0 indexed. So in order to test a second call on a mock, `$this->at(1)` is the correct answer.

I fixed the answer and left `$this->at(2)` to confuse the candidate.
I also removed one answer.