### PR TITLE
Fixed answers for the question about Twig classes

### DIFF
--- a/data/templating.yml
+++ b/data/templating.yml
@@ -130,8 +130,7 @@ questions:
             - {value: 'setArguments, getArguments', correct: false}
             - {value: 'isValid()', correct: false}
             - {value: 'setPriority(), getPriority()', correct: false}
-            - {value: 'a combination of a and c', correct: false}
-            - {value: 'none of the above', correct: true}
+            - {value: 'none of these options', correct: true}
     -
         question: 'In Twig this statement is valid:'
         answers:


### PR DESCRIPTION
The answer 'a combination of a and c' makes no sense because there is no a and c, there are answers from 0 to 5.
The answer 'none of the above' is also incorrect because answers are shuffled and 'above'-answer can be the first option.