### PR TITLE
fixed console helpers question

### DIFF
--- a/data/command-line.yml
+++ b/data/command-line.yml
@@ -1,13 +1,6 @@
 category: The Command Line
 questions:
     -
-        question: 'Which helper is not available in the Console component?'
-        answers:
-            - {value: QuestionHelper, correct: true}
-            - {value: TableHelper,    correct: false}
-            - {value: FileHelper,     correct: true}
-            - {value: DialogHelper,   correct: false}
-    -
         question: 'Which event is not available in the Console Component?'
         answers:
             - {value: ConsoleEvents::COMMAND,   correct: false}

--- a/data/symfony3.yml
+++ b/data/symfony3.yml
@@ -7,3 +7,11 @@ questions:
             - {value: 'SIGKILL',        correct: true}
             - {value: 'Process::STOP',  correct: false}
             - {value: '9',              correct: true}
+    -
+        question: 'Which helper is not available in the Console component?'
+        answers:
+            - {value: QuestionHelper, correct: false}
+            - {value: TableHelper,    correct: false}
+            - {value: FileHelper,     correct: true}
+            - {value: DialogHelper,   correct: true}
+


### PR DESCRIPTION
Dialog helper is deprecated, and Question helper available. Put in Symfony3 section, because Dialog helper is removed in Symfony3.

http://symfony.com/doc/current/components/console/helpers/index.html