### PR TITLE
Mistake in cli multi answer options

### DIFF
--- a/data/command-line.yml
+++ b/data/command-line.yml
@@ -90,7 +90,7 @@ questions:
         answers:
             - {value: "php app/console dump:config acme",                   correct: false}
             - {value: "php app/console config:dump-reference acme",         correct: true}
-            - {value: "php app/console config:dump AcmeBundle",             correct: false}
+            - {value: "php app/console config:dump AcmeBundle",             correct: true}
             - {value: "php app/console config:dump-reference AcmeBundle",   correct: true}
     -
         question: 'Descriptors are objects to render documentation on Symfony Console Apps?'


### PR DESCRIPTION
As Symfony console supports unambiguous commands, shortcuts are allowed to be used, as long as there's no clashing commands. Therefore "config:reference-dump" can be called with "config:dump", "config:d", "conf:d" or even "c:d".