### PR TITLE
Changed class type to quoted string string

### DIFF
--- a/data/forms.yml
+++ b/data/forms.yml
@@ -118,5 +118,5 @@ questions:
         question: 'How to add an extra field `extra` with the form ?'
         answers:
             - {value: "$builder->add('extra', null, ['mapped' => false])",    correct: true}
-            - {value: "$builder->add('extra', hidden, ['mapped' => false])",  correct: true}
+            - {value: "$builder->add('extra', 'hidden', ['mapped' => false])",  correct: true}
             - {value: "$builder->add('extra', null, ['validation' => false]", correct: false}


### PR DESCRIPTION
The answer  "$builder->add('extra', hidden, ['mapped' => false])" makes a confusion, it should be quoted to look as a correct answer.