### PR TITLE
The Console Component provides a QuestionHelper, but not a DialogHelper

### DIFF
--- a/data/command-line.yml
+++ b/data/command-line.yml
@@ -3,10 +3,10 @@ questions:
     -
         question: 'Which helper is not available in the Console component?'
         answers:
-            - {value: QuestionHelper, correct: true}
+            - {value: QuestionHelper, correct: false}
             - {value: TableHelper,    correct: false}
             - {value: FileHelper,     correct: true}
-            - {value: DialogHelper,   correct: false}
+            - {value: DialogHelper,   correct: true}
     -
         question: 'Which event is not available in the Console Component?'
         answers:


### PR DESCRIPTION
The answers to the question "Which helper is not available in the Console component" are not correct. QuestionHelper is a valid helper, instead of the DialogHelper.

See http://symfony.com/doc/current/components/console/helpers/index.html