### PR TITLE
fix answer on 404 template

### DIFF
--- a/data/templating.yml
+++ b/data/templating.yml
@@ -64,7 +64,7 @@ questions:
     -
         question: 'If you want to overwrite the 404 page, what is the relative path of the template to create ?'
         answers:
-            - {value: app/Resources/TwigBundle/views/Exception/error.html.twig,         correct: true}
+            - {value: app/Resources/TwigBundle/views/Exception/error.html.twig,         correct: false}
             - {value: app/Resources/TwigBundle/views/Exception/error404.html.twig,      correct: true}
             - {value: app/Resources/views/Exception/error.html.twig,                    correct: false}
             - {value: app/Resources/TwigBundle/views/Exception/error.twig,              correct: false}


### PR DESCRIPTION
see http://symfony.com/doc/current/controller/error_pages.html#overriding-the-default-error-templates

"app/Resources/TwigBundle/views/Exception/error.html.twig" is not valid cause it's for other error codes.